### PR TITLE
Update deseq2.py

### DIFF
--- a/deseq2py/tools/deseq2.py
+++ b/deseq2py/tools/deseq2.py
@@ -71,7 +71,8 @@ def run(adata,formula,**kwargs):
     
 def vst(adata):
     logg.info("Obtaining vsd", end="\n")
-    vsd=deseq.vst(adata.uns["dds"], blind=False)
+    nsub = min(sum(adata.layers["normalized"].mean(axis=0) > 5), 1000)
+    vsd = deseq.vst(adata.uns["dds"], nsub=nsub, blind=False)
     adata.layers["vsd"] = SE.assay(vsd).T
     logg.info(
         "    done",


### PR DESCRIPTION
While performing on really sparse datasets with low coverage (e.g. scATAC pseudobulk per cell type) nsubs = 1000 (default) leads to an error `less than 'nsub' rows with mean normalized count > 5`